### PR TITLE
Stop Options kwargs from rewriting the class-level defaults

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,66 @@
+"""Options: per-method defaults are per-instance, not rewritten by earlier kwargs."""
+import copy
+
+from vamtoolbox.optimize import Options
+
+
+def _class_defaults():
+    """Snapshot of the class-level default dicts (name-mangled attributes)."""
+    return {
+        name: copy.deepcopy(getattr(Options, "_Options__default_%s" % name))
+        for name in ("FBP", "CAL", "PM", "OSMO", "BCLP")
+    }
+
+
+def test_kwargs_do_not_change_later_defaults():
+    Options(method="BCLP", learning_rate=0.5, verbose="off")
+    later = Options(method="BCLP", verbose="off")
+    assert later.learning_rate == 0.01
+
+
+def test_kwargs_do_not_leak_across_methods():
+    Options(method="BCLP", learning_rate=0.5, verbose="off")
+    cal = Options(method="CAL", verbose="off")
+    assert cal.learning_rate == 0.01
+
+
+def test_class_defaults_are_not_mutated():
+    before = _class_defaults()
+    Options(method="BCLP", learning_rate=0.5, eps=0.9, weight=7, verbose="off")
+    Options(method="CAL", momentum=0.3, sigmoid=0.5, verbose="off")
+    Options(method="PM", rho_1=9, verbose="off")
+    Options(method="OSMO", inhibition=0.4, verbose="off")
+    Options(method="FBP", offset=True)
+    assert _class_defaults() == before
+
+
+def test_kwargs_still_apply_to_their_own_instance():
+    """Backward compatibility: the instance given the kwarg still receives it."""
+    bclp = Options(method="BCLP", learning_rate=0.5, eps=0.9, weight=7, q=3, verbose="off")
+    assert (bclp.learning_rate, bclp.eps, bclp.weight, bclp.q) == (0.5, 0.9, 7, 3)
+
+    cal = Options(method="CAL", learning_rate=0.2, momentum=0.3, positivity=0.4, sigmoid=0.5)
+    assert (cal.learning_rate, cal.momentum, cal.positivity, cal.sigmoid) == (0.2, 0.3, 0.4, 0.5)
+
+    pm = Options(method="PM", rho_1=9, rho_2=8, p=4)
+    assert (pm.rho_1, pm.rho_2, pm.p) == (9, 8, 4)
+
+    osmo = Options(method="OSMO", inhibition=0.4)
+    assert osmo.inhibition == 0.4
+
+    fbp = Options(method="FBP", offset=True)
+    assert fbp.offset is True
+
+
+def test_unknown_kwargs_are_still_stored_on_the_instance():
+    opt = Options(method="CAL", some_extra_setting=123)
+    assert opt.some_extra_setting == 123
+
+
+def test_explicit_response_model_does_not_become_the_default():
+    from vamtoolbox import response
+
+    model = response.ResponseModel()
+    Options(method="BCLP", response_model=model, verbose="off")
+    later = Options(method="BCLP", verbose="off")
+    assert later.response_model is not model

--- a/vamtoolbox/optimize.py
+++ b/vamtoolbox/optimize.py
@@ -117,13 +117,15 @@ class Options:
         self.blb = blb
         self.bub = bub
 
-        self.__default_FBP.update(kwargs)
-        self.__default_CAL.update(kwargs)
-        self.__default_PM.update(kwargs)
-        self.__default_OSMO.update(kwargs)
-        self.__default_BCLP.update(
-            kwargs
-        )  # TODO: The class definition of dict "__default_BCLP" should not be edited in place here.
+        # Merge kwargs onto a copy of each default set.  Updating the class
+        # attributes in place would rewrite the defaults for every Options
+        # created later in the same session, so a second instance would silently
+        # inherit the first one's kwargs instead of the documented defaults.
+        default_FBP = {**self.__default_FBP, **kwargs}
+        default_CAL = {**self.__default_CAL, **kwargs}
+        default_PM = {**self.__default_PM, **kwargs}
+        default_OSMO = {**self.__default_OSMO, **kwargs}
+        default_BCLP = {**self.__default_BCLP, **kwargs}
         self.__dict__.update(kwargs)  # Store all the extra variables
 
         self.verbose = self.__dict__.get("verbose", False)
@@ -132,38 +134,38 @@ class Options:
         self.exit_param = self.__dict__.get("exit_param", None)
 
         if method == "FBP":
-            self.offset = self.__default_FBP["offset"]
+            self.offset = default_FBP["offset"]
 
         if method == "CAL":
-            self.learning_rate = self.__default_CAL["learning_rate"]
-            self.momentum = self.__default_CAL["momentum"]
-            self.positivity = self.__default_CAL["positivity"]
-            self.sigmoid = self.__default_CAL["sigmoid"]
+            self.learning_rate = default_CAL["learning_rate"]
+            self.momentum = default_CAL["momentum"]
+            self.positivity = default_CAL["positivity"]
+            self.sigmoid = default_CAL["sigmoid"]
 
         if method == "PM":
-            self.rho_1 = self.__default_PM["rho_1"]
-            self.rho_2 = self.__default_PM["rho_2"]
-            self.p = self.__default_PM["p"]
+            self.rho_1 = default_PM["rho_1"]
+            self.rho_2 = default_PM["rho_2"]
+            self.p = default_PM["p"]
 
         if method == "OSMO":
-            self.inhibition = self.__default_OSMO["inhibition"]
+            self.inhibition = default_OSMO["inhibition"]
 
         if method == "BCLP":
-            if self.__default_BCLP["response_model"] == "default":
+            if default_BCLP["response_model"] == "default":
                 # Initialize a response model by default, only upon __init__ of Options class.
                 # This avoids putting the ResponseModel object inside the class definition of Options (and hence avoid import problems and unnesscary init of default response model)
                 self.response_model = vamtoolbox.response.ResponseModel()
             else:
                 # If a response model is given, use the provided one instead.
-                self.response_model = self.__default_BCLP["response_model"]  # type: ignore
+                self.response_model = default_BCLP["response_model"]  # type: ignore
 
-            self.eps = self.__default_BCLP["eps"]
-            self.weight = self.__default_BCLP["weight"]
-            self.p = self.__default_BCLP["p"]  # type: ignore
-            self.q = self.__default_BCLP["q"]  # type: ignore
-            self.learning_rate = self.__default_BCLP["learning_rate"]  # type: ignore
-            self.optim_alg = self.__default_BCLP["optim_alg"]
-            self.g0 = self.__default_BCLP["g0"]
+            self.eps = default_BCLP["eps"]
+            self.weight = default_BCLP["weight"]
+            self.p = default_BCLP["p"]  # type: ignore
+            self.q = default_BCLP["q"]  # type: ignore
+            self.learning_rate = default_BCLP["learning_rate"]  # type: ignore
+            self.optim_alg = default_BCLP["optim_alg"]
+            self.g0 = default_BCLP["g0"]
             self.test_alternate_handling = self.__dict__.get(
                 "test_alternate_handling", False
             )  # flag for testing alternate handling. Default: False. This will override original weight setting. Will be removed for actual release


### PR DESCRIPTION
This PR proposes stopping `Options.__init__` from rewriting the class-level default dicts, so a second `Options` in the same session starts from the documented defaults instead of the previous instance's kwargs (Fixes #21). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/200. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`Options.__init__` merged `**kwargs` into the class attributes with `dict.update()`, which edits those dicts in place — and it did so for all five method dicts (`__default_FBP`, `__default_CAL`, `__default_PM`, `__default_OSMO`, `__default_BCLP`), not only the one flagged in #21. Because every dict receives the same `**kwargs`, the leak also crosses methods: a `learning_rate` passed to a BCLP run silently becomes the CAL default as well. Nothing errors, so a session that tunes one optimization and then builds a fresh `Options` gets quietly different numbers — matching the "recently gave me erroneous results" report.

Reproduced on `main` at c2757e6:

```
$ python -c "
from vamtoolbox.optimize import Options
a = Options(method='BCLP', learning_rate=0.5)
print('B:', Options(method='BCLP').learning_rate)
print('C(CAL):', Options(method='CAL').learning_rate)
print('class default:', Options._Options__default_BCLP['learning_rate'])"
B: 0.5
C(CAL): 0.5
class default: 0.5
```

All three should read `0.01`. Your own suite carries the latent form of this: `test_bclp_diffusion_runs` passes an explicit `response_model=`, which permanently replaces the BCLP default for every `Options` built later in that process, so the suite's result depends on test order.

## The change

`__init__` now merges the kwargs onto per-instance copies (`{**self.__default_BCLP, **kwargs}`) and reads the method block from those locals, leaving the class definitions untouched. This is deliberately the smallest change that fixes it — the `# TODO: make options a dataclass` note above the class is left alone. Kwargs still apply to the instance they are passed to and unknown kwargs are still stored on the instance, so existing callers see no difference; the only behavior that changes is the leak into later instances.

## Verification

`tests/test_options.py` adds six tests: the leak between instances, the leak across methods, the class dicts staying pristine after constructing with kwargs for all five methods, an explicit `response_model` not becoming the default, plus two backward-compatibility controls asserting kwargs still reach their own instance. On the unmodified tree four of the six fail (the two controls pass, which is what shows they are controls); with the change all six pass.

Full suite before the change: `36 passed, 1 skipped` (the skip is `test_projectors.py` needing CUDA). After: `42 passed, 1 skipped` — the same 36, the same skip, plus the 6 new tests. No new failures. Run with `python -m pytest` on Python 3.12.

## How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests — 28 stories and 4 labels — with the fix carried on the story for #21 at https://eastagiletracker.com/projects/200/stories/60623, alongside the rest of the board at https://eastagiletracker.com/projects/200.

![board](https://raw.githubusercontent.com/eastagiletracker/VAMToolbox/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
